### PR TITLE
Altered reporting to allow for an 'All' report, fixed attendance bugs

### DIFF
--- a/GrantTracker/ClientApp/src/components/SessionDetails/AttendanceHistory/RecordDisplay.tsx
+++ b/GrantTracker/ClientApp/src/components/SessionDetails/AttendanceHistory/RecordDisplay.tsx
@@ -217,8 +217,9 @@ export default ({sessionGuid, simpleRecord, onDeleteClick, sessionType}: Props):
           <div className='d-flex flex-row align-items-center'>
             <div>{simpleRecord.instanceDate.format(DateTimeFormatter.ofPattern('eeee, MMMM d').withLocale(Locale.ENGLISH))}</div>
             <ul className='m-0'>
-              <li>{simpleRecord.instructorCount} Instructor Record(s)</li>
-              <li>{simpleRecord.studentCount} Student Record(s)</li>
+              {simpleRecord.instructorCount > 0 ? <li>{simpleRecord.instructorCount} Instructor Record(s)</li> : null}
+              {simpleRecord.studentCount > 0 ? <li>{simpleRecord.studentCount} Student Record(s)</li> : null}
+              {simpleRecord.familyCount > 0 ? <li>{simpleRecord.familyCount} Family Record(s)</li> : null}
             </ul>
           </div>
         </Accordion.Header>
@@ -233,8 +234,9 @@ export default ({sessionGuid, simpleRecord, onDeleteClick, sessionType}: Props):
         <div className='d-flex flex-row align-items-center'>
           <div>{simpleRecord.instanceDate.format(DateTimeFormatter.ofPattern('eeee, MMMM d').withLocale(Locale.ENGLISH))}</div>
           <ul className='m-0'>
-            <li>{simpleRecord.instructorCount} Instructor Record(s)</li>
-            <li>{simpleRecord.studentCount} Student Record(s)</li>
+            {simpleRecord.instructorCount > 0 ? <li>{simpleRecord.instructorCount} Instructor Record(s)</li> : null}
+            {simpleRecord.studentCount > 0 ? <li>{simpleRecord.studentCount} Student Record(s)</li> : null}
+            {simpleRecord.familyCount > 0 ? <li>{simpleRecord.familyCount} Family Record(s)</li> : null}
           </ul>
         </div>
       </Accordion.Header>
@@ -244,10 +246,6 @@ export default ({sessionGuid, simpleRecord, onDeleteClick, sessionType}: Props):
             className='btn btn-primary my-3 mx-3'
             to={attendanceHref}
             style={{width: 'fit-content'}}
-            onClick={(e) => {
-              e.preventDefault()
-              window.open(attendanceHref, '_blank')
-            }}
           >
             Edit Record
           </Link>

--- a/GrantTracker/ClientApp/src/components/SessionDetails/AttendanceHistory/TimeRecordDisplay.tsx
+++ b/GrantTracker/ClientApp/src/components/SessionDetails/AttendanceHistory/TimeRecordDisplay.tsx
@@ -4,13 +4,13 @@ import { Locale } from '@js-joda/locale_en-us'
 import { AttendanceTimeRecordView } from 'Models/StudentAttendance'
 
 export default ({timeRecords}: {timeRecords: AttendanceTimeRecordView[]}): JSX.Element => {
-  timeRecords = timeRecords.sort((first, second) => {
+  timeRecords = timeRecords?.sort((first, second) => {
     if (first.startTime.isBefore(second.startTime))
       return -1
     if (first.endTime.isAfter(second.endTime))
       return 1
     return 0
-  })
+  }) || []
 
   return (
     <div className='row h-100 align-items-center'>

--- a/GrantTracker/ClientApp/src/components/SessionDetails/Scheduling.tsx
+++ b/GrantTracker/ClientApp/src/components/SessionDetails/Scheduling.tsx
@@ -23,7 +23,6 @@ export default ({ session }: Props): JSX.Element => {
           <ListGroup variant='flush'>
             {session!.daySchedules.map((item: DayScheduleView) => (
               <Item>
-                {console.log(`&dow=${DayOfWeek.toInt(item.dayOfWeek)}`)}
                 <p>{item.dayOfWeek}</p>
                 <div className='d-flex flex-column'>
                   {item.timeSchedules.map(schedule => (
@@ -37,10 +36,6 @@ export default ({ session }: Props): JSX.Element => {
                   className='btn btn-sm btn-primary'
                   to={attendanceHref + `&dow=${DayOfWeek.toInt(item.dayOfWeek)}`}
                   style={{ height: 'min-content', maxWidth: '30%'}}
-                  onClick={(e) => {
-                    e.preventDefault()
-                    window.open(attendanceHref + `&dow=${DayOfWeek.toInt(item.dayOfWeek)}`, '_blank')
-                  }}
                 >
                   Attendance
                 </Link>

--- a/GrantTracker/ClientApp/src/components/SessionDetails/api.ts
+++ b/GrantTracker/ClientApp/src/components/SessionDetails/api.ts
@@ -36,7 +36,8 @@ export function getSimpleAttendanceRecords (sessionGuid): Promise<SimpleAttendan
           guid: viewModel.attendanceGuid,
           instanceDate: DateOnly.toLocalDate(viewModel.instanceDate),
           instructorCount: viewModel.instructorCount,
-          studentCount: viewModel.studentCount
+          studentCount: viewModel.studentCount,
+          familyCount: viewModel.familyCount
         } as SimpleAttendanceView))
 
         viewModels = viewModels.sort((first: SimpleAttendanceView, second: SimpleAttendanceView) => {

--- a/GrantTracker/ClientApp/src/components/TimeRangeSelector/Input/helpers.ts
+++ b/GrantTracker/ClientApp/src/components/TimeRangeSelector/Input/helpers.ts
@@ -1,5 +1,4 @@
 ﻿import { InputAction } from 'components/TimeRangeSelector/types'
-import e from 'express'
 import { range } from 'utils/Array'
 
 function getActionFromKey (nativeEvent: KeyboardEvent): InputAction {
@@ -8,7 +7,7 @@ function getActionFromKey (nativeEvent: KeyboardEvent): InputAction {
   else if (nativeEvent.code === 'ArrowRight') return InputAction.MoveRight
   else if (nativeEvent.code === 'ArrowLeft') return InputAction.MoveLeft
   else if (nativeEvent.code === 'Enter') return InputAction.Submit
-  else if (range(48, 57).includes(nativeEvent.keyCode))
+  else if (range(0, 9).includes(Number(nativeEvent.key)))
     return InputAction.TypeDigit
   else if (range(65, 90).includes(nativeEvent.keyCode))
     return InputAction.TypeChar

--- a/GrantTracker/ClientApp/src/models/OrganizationYear.ts
+++ b/GrantTracker/ClientApp/src/models/OrganizationYear.ts
@@ -29,7 +29,7 @@ export enum Quarter {
 }
 
 export interface YearDomain {
-  yearGuid: string
+  guid: string
   schoolYear: string
   quarter: number
   isCurrentYear: boolean
@@ -38,7 +38,7 @@ export interface YearDomain {
 }
 
 export interface YearView {
-  yearGuid: string
+  guid: string
   schoolYear: string
   quarter: Quarter
   isCurrentYear: boolean

--- a/GrantTracker/ClientApp/src/models/StudentAttendance.ts
+++ b/GrantTracker/ClientApp/src/models/StudentAttendance.ts
@@ -53,6 +53,7 @@ export interface SimpleAttendanceView {
   instanceDate: LocalDate
   instructorCount: number
   studentCount: number
+  familyCount: number
 }
 
 export interface AttendanceView {

--- a/GrantTracker/ClientApp/src/pages/Admin/Attendance/StudentAttendance.tsx
+++ b/GrantTracker/ClientApp/src/pages/Admin/Attendance/StudentAttendance.tsx
@@ -32,6 +32,11 @@ export const StudentAttendance = ({ orgYearGuid, state, dispatch, sessionType })
 
     let columns: Column[] = createCoreStudentColumns(dispatch)
 
+    if (sessionType === 'Family') {
+        columns[0].label = 'Anyone Present'
+        columns = [createFamilyStudentPresenceColumn(dispatch), ...columns]
+    }
+
     if (sessionType !== 'Parent')
         columns = [...columns, ...createTimeEntryColumns(dispatch)]
 
@@ -143,6 +148,25 @@ const createParentAttendanceColumn = (dispatch: React.Dispatch<ReducerAction>): 
                 </DropdownButton>
             </>
         )
+    }
+})
+
+const createFamilyStudentPresenceColumn = (dispatch: React.Dispatch<ReducerAction>): Column => ({
+    label: 'Student Present',
+    attributeKey: '',
+    sortable: false,
+    transform: (record: StudentRecord) => (
+        <div
+            role='button'
+            className='d-flex justify-content-center align-items-center'
+            onClick={() => dispatch({ type: 'familyStudentPresence', payload: { guid: record.id, isPresent: !record.isPresent } })}
+            style={{ minHeight: '100%' }}
+        >
+            <Form.Check checked={record.times.length > 0} onChange={(e) => { }} />
+        </div>
+    ),
+    cellProps: {
+        style: { height: '1px', padding: '0px' }
     }
 })
 

--- a/GrantTracker/ClientApp/src/pages/Admin/Attendance/Summary.tsx
+++ b/GrantTracker/ClientApp/src/pages/Admin/Attendance/Summary.tsx
@@ -49,6 +49,9 @@ export const AttendanceSummary = ({ sessionGuid, sessionType, attendanceGuid, da
 	let studentColumns: Column[] = coreColumns.slice();
 	let instructorColumns: Column[] = [...coreColumns.slice(), {...entryExitColumn}];
 
+	if (sessionType === 'Family')
+		studentColumns = [studentPresentColumn, ...studentColumns]
+
     if (sessionType !== 'Parent')
 		studentColumns = [...studentColumns, {...entryExitColumn}]
 
@@ -57,7 +60,7 @@ export const AttendanceSummary = ({ sessionGuid, sessionType, attendanceGuid, da
 
 	const instructors: InstructorRecord[] = state.instructorRecords.filter(x => x.isPresent && !x.isSubstitute)
 	const substitutes: InstructorRecord[] = state.instructorRecords.filter(x => x.isPresent && x.isSubstitute)
-	const students: StudentRecord[] = state.studentRecords.filter(x => x.isPresent)
+	const students: StudentRecord[] = state.studentRecords.filter(x => x.isPresent).filter(x => sessionType !== 'Parent' || x.familyAttendance.length > 0)
 
 	return (
 		<div className='row'>
@@ -187,7 +190,16 @@ const entryExitColumn: Column = {
 	cellProps: cellProps
 }
 
-const familyAttendColumn = {
+const studentPresentColumn: Column = {
+	label: 'Student Present',
+	attributeKey: '',
+	sortable: false,
+	headerProps: cellProps,
+	cellProps: cellProps,
+	transform: (record: StudentRecord) => record.times.length > 0 ? <span className='text-success'>Y</span> : <span className='text-danger'>N</span>
+}
+
+const familyAttendColumn: Column = {
 	label: 'Family Attendance',
 	attributeKey: 'familyAttendance',
 	key: 'familyAttendance',

--- a/GrantTracker/ClientApp/src/pages/Admin/Attendance/TimeComponents.tsx
+++ b/GrantTracker/ClientApp/src/pages/Admin/Attendance/TimeComponents.tsx
@@ -26,7 +26,7 @@ export const AttendanceStartTimeInput = ({personId, times, dispatch}: Attendance
 					id={'start-time-' + personId + index} 
 					small={true}
 					value={schedule.startTime} 
-					onChange={(time) => dispatch({ type: 'setAttendanceTime', payload: { personId, times: modifyTimesByIndex(index, time)}})} 
+					onChange={(time) => dispatch({ type: 'setAttendanceStartTime', payload: { personId, times: modifyTimesByIndex(index, time)}})} 
 				/>
 			</div>
 		)
@@ -45,7 +45,7 @@ export const AttendanceEndTimeInput = ({personId, times, dispatch}: AttendanceTi
 					id={'end-time-' + personId + index} 
 					small={true}
 					value={schedule.endTime} 
-					onChange={(time) => dispatch({ type: 'setAttendanceTime', payload: { personId, times: modifyTimesByIndex(index, time)}})} 
+					onChange={(time) => dispatch({ type: 'setAttendanceEndTime', payload: { personId, times: modifyTimesByIndex(index, time)}})} 
 				/>
 			</div>
 		)

--- a/GrantTracker/ClientApp/src/pages/Admin/Sessions/index.tsx
+++ b/GrantTracker/ClientApp/src/pages/Admin/Sessions/index.tsx
@@ -26,8 +26,6 @@ export default (): JSX.Element => {
     const { orgYear, setOrgYear } = useContext(OrgYearContext)
     const [searchTerm, setSearchTerm] = useState<string>('')
 
-    console.log(orgYear)
-
     const { isPending: sessionsLoading, data: sessions } = useQuery<SimpleSessionView[]>({
         queryKey: [`session?orgYearGuid=${orgYear?.guid}`],
         enabled: !!orgYear?.guid,

--- a/GrantTracker/ClientApp/src/pages/Reporting/Definitions/CSV.ts
+++ b/GrantTracker/ClientApp/src/pages/Reporting/Definitions/CSV.ts
@@ -1,168 +1,171 @@
+import { DateTimeFormatter } from "@js-joda/core"
+import { Locale } from "@js-joda/locale_en-us"
 import { DateOnly } from "Models/DateOnly"
+import { TimeOnly } from "Models/TimeOnly"
 
 export const studentAttendanceFields = [
-  {
-	label: 'Organization',
-	value: 'organizationName'
-  },
-  {
-	label: 'Last Name',
-	value: 'lastName'
-  },
-  {
-	label: 'First Name',
-	value: 'firstName'
-  },
-  {
-	label: 'Matric Number',
-	value: 'matricNumber'
-  },
-  {
-	label: 'Grade',
-	value: 'grade',
-  },
-  {
-	label: 'Total Days',
-	value: 'totalDays'
-  },
-  {
-	label: 'Total Hours',
-	value: 'totalHours'
-  },
+	{
+		label: 'Organization',
+		value: 'organizationName'
+	},
+	{
+		label: 'Last Name',
+		value: 'lastName'
+	},
+	{
+		label: 'First Name',
+		value: 'firstName'
+	},
+	{
+		label: 'Matric Number',
+		value: 'matricNumber'
+	},
+	{
+		label: 'Grade',
+		value: 'grade',
+	},
+	{
+		label: 'Total Days',
+		value: 'totalDays'
+	},
+	{
+		label: 'Total Hours',
+		value: 'totalHours'
+	},
 ]
 
 export const familyAttendanceFields = [
-    {
-      label: 'Organization',
-      value: 'organizationName'
-    },
-    {
-      label: 'Last Name',
-      value: 'lastName'
-    },
-    {
-      label: 'First Name',
-      value: 'firstName'
-    },
-    {
-      label: 'Matric Number',
-      value: 'matricNumber'
-    },
-    {
-      label: 'Grade',
-      value: 'grade',
-    },
-    {
-      label: 'Family Member',
-      value: 'familyMember'
-    },
-    {
-      label: 'Total Days',
-      value: 'totalDays'
-    },
-    {
-      label: 'Total Hours',
-      value: 'totalHours'
-    }
+	{
+		label: 'Organization',
+		value: 'organizationName'
+	},
+	{
+		label: 'Last Name',
+		value: 'lastName'
+	},
+	{
+		label: 'First Name',
+		value: 'firstName'
+	},
+	{
+		label: 'Matric Number',
+		value: 'matricNumber'
+	},
+	{
+		label: 'Grade',
+		value: 'grade',
+	},
+	{
+		label: 'Family Member',
+		value: 'familyMember'
+	},
+	{
+		label: 'Total Days',
+		value: 'totalDays'
+	},
+	{
+		label: 'Total Hours',
+		value: 'totalHours'
+	}
 ]
 
 export const flattenFamilyAttendance = (data) => {
 	let flattenedData: any[] = []
 
 	data.forEach(x => {
-    flattenedData = [
-      ...flattenedData,
-      ...x.familyAttendance.map(fa => ({
-        organizationName: x.organizationName,
-        firstName: x.firstName,
-        lastName: x.lastName,
-        grade: x.grade,
-        matricNumber: x.matricNumber,
-        familyMember: fa.familyMember,
-        totalDays: fa.totalDays,
-        totalHours: fa.totalHours
-      }))
-    ]
-  })
+		flattenedData = [
+			...flattenedData,
+			...x.familyAttendance.map(fa => ({
+				organizationName: x.organizationName,
+				firstName: x.firstName,
+				lastName: x.lastName,
+				grade: x.grade,
+				matricNumber: x.matricNumber,
+				familyMember: fa.familyMember,
+				totalDays: fa.totalDays,
+				totalHours: fa.totalHours
+			}))
+		]
+	})
 
-  return flattenedData
+	return flattenedData
 }
 
 export const activityFields = [
-    {
-      label: 'Organization',
-      value: 'organizationName'
-    },
-    {
-      label: 'Activity Type',
-      value: 'activity'
-    },
-    {
-      label: 'Total Attendees',
-      value: 'totalAttendees'
-    },
-    {
-      label: 'Total Hours',
-      value: 'totalHours',
-    }
+	{
+		label: 'Organization',
+		value: 'organizationName'
+	},
+	{
+		label: 'Activity Type',
+		value: 'activity'
+	},
+	{
+		label: 'Total Attendees',
+		value: 'totalAttendees'
+	},
+	{
+		label: 'Total Hours',
+		value: 'totalHours',
+	}
 ]
 
 export const siteSessionFields = [
-    {
-      label: 'Organization',
-      value: 'organizationName'
-    },
-    {
-      label: 'Name',
-      value: 'sessionName'
-    },
-    {
-      label: 'Activity Type',
-      value: 'activityType'
-    },
-    {
-      label: 'Objective',
-      value: 'objective'
-    },
-    {
-      label: 'Funding Source',
-      value: 'fundingSource'
-    },
-    {
-      label: 'Partnership Type',
-      value: 'partnershipType'
-    },
-    {
-      label: 'Organization Type',
-      value: 'organizationType'
-    },
-    {
-      label: 'Instructor Last Name',
-      value: 'instructorLastName'
-    },
-    {
-      label: 'Instructor First Name',
-      value: 'instructorFirstName'
-    },
-    {
-      label: 'Instructor Status',
-      value: 'instructorStatus'
-    },
-    {
-      label: 'Grades',
-      value: 'grades'
-    },
-    {
-      label: 'Number of Participants',
-      value: 'attendeeCount'
-    },
-  ]
+	{
+		label: 'Organization',
+		value: 'organizationName'
+	},
+	{
+		label: 'Name',
+		value: 'sessionName'
+	},
+	{
+		label: 'Activity Type',
+		value: 'activityType'
+	},
+	{
+		label: 'Objective',
+		value: 'objective'
+	},
+	{
+		label: 'Funding Source',
+		value: 'fundingSource'
+	},
+	{
+		label: 'Partnership Type',
+		value: 'partnershipType'
+	},
+	{
+		label: 'Organization Type',
+		value: 'organizationType'
+	},
+	{
+		label: 'Instructor Last Name',
+		value: 'instructorLastName'
+	},
+	{
+		label: 'Instructor First Name',
+		value: 'instructorFirstName'
+	},
+	{
+		label: 'Instructor Status',
+		value: 'instructorStatus'
+	},
+	{
+		label: 'Grades',
+		value: 'grades'
+	},
+	{
+		label: 'Number of Participants',
+		value: 'attendeeCount'
+	},
+]
 
 
 export const flattenSiteSessions = (data) => {
 	let flattenedData: any[] = []
 
-  	data.forEach(session => {
+	data.forEach(session => {
 		if (session.instructors.length !== 0) {
 			session.instructors.forEach(i => {
 				flattenedData = [
@@ -273,22 +276,22 @@ export const flattenSummaryOfClasses = (data) => {
 		if (session.instructors.length !== 0) {
 			session.instructors.forEach(i => {
 				flattenedData = [
-				...flattenedData,
-				{
-					organizationName: session.organizationName,
-					sessionName: session.sessionName,
-					activityType: session.activityType,
-					fundingSource: session.fundingSource,
-					instructorLastName: i.lastName,
-					instructorFirstName: i.firstName,
-					instructorStatus: i.status,
-					startDate: DateOnly.toLocalDate(session.firstSession).toString(),
-					endDate: DateOnly.toLocalDate(session.lastSession).toString(),
-					weeksToDate: session.weeksToDate,
-					//daysOfWeek: session.daysOfWeek.map(day => `${DayOfWeek.toChar(day)}`).toString(),
-					avgDailyAttendance: session.avgDailyAttendance,
-					avgHoursPerDay: session.avgHoursPerDay
-				}
+					...flattenedData,
+					{
+						organizationName: session.organizationName,
+						sessionName: session.sessionName,
+						activityType: session.activityType,
+						fundingSource: session.fundingSource,
+						instructorLastName: i.lastName,
+						instructorFirstName: i.firstName,
+						instructorStatus: i.status,
+						startDate: DateOnly.toLocalDate(session.firstSession).toString(),
+						endDate: DateOnly.toLocalDate(session.lastSession).toString(),
+						weeksToDate: session.weeksToDate,
+						//daysOfWeek: session.daysOfWeek.map(day => `${DayOfWeek.toChar(day)}`).toString(),
+						avgDailyAttendance: session.avgDailyAttendance,
+						avgHoursPerDay: session.avgHoursPerDay
+					}
 				]
 			})
 		}
@@ -312,62 +315,62 @@ export const flattenSummaryOfClasses = (data) => {
 				}
 			]
 		}
-		
+
 	})
 
-  	return flattenedData
+	return flattenedData
 }
 
 
 export const programOverviewFields = [
-    {
-      label: 'Organization Name',
-      value: 'organizationName'
-    },
-    {
-      label: '# of Regular Students',
-      value: 'regularStudentCount'
-    },
-    {
-      label: '# of Family Attendees',
-      value: 'familyAttendanceCount',
-    },
-    {
-      label: 'Student Days Offered',
-      value: 'studentDaysOfferedCount'
-    },
-    {
-      label: 'Avg Daily Unique Student Attendance',
-      value: 'avgStudentDailyAttendance'
-    },
-    {
-      label: 'Avg Student Attendance Days Per Week',
-      value: 'avgStudentAttendDaysPerWeek'
-    },
-    {
-      label: 'Avg Student Attendance Hours Per Week',
-      value: 'avgStudentAttendHoursPerWeek'
-    }
+	{
+		label: 'Organization Name',
+		value: 'organizationName'
+	},
+	{
+		label: '# of Regular Students',
+		value: 'regularStudentCount'
+	},
+	{
+		label: '# of Family Attendees',
+		value: 'familyAttendanceCount',
+	},
+	{
+		label: 'Student Days Offered',
+		value: 'studentDaysOfferedCount'
+	},
+	{
+		label: 'Avg Daily Unique Student Attendance',
+		value: 'avgStudentDailyAttendance'
+	},
+	{
+		label: 'Avg Student Attendance Days Per Week',
+		value: 'avgStudentAttendDaysPerWeek'
+	},
+	{
+		label: 'Avg Student Attendance Hours Per Week',
+		value: 'avgStudentAttendHoursPerWeek'
+	}
 ]
 
 
 export const staffingFields = [
-    {
-      label: 'Organization',
-      value: 'organizationName'
-    },
-    {
-      label: 'Status',
-      value: 'status'
-    },
-    {
-      label: 'Last Name',
-      value: 'lastName'
-    },
-    {
-      label: 'First Name',
-      value: 'firstName'
-    }
+	{
+		label: 'Organization',
+		value: 'organizationName'
+	},
+	{
+		label: 'Status',
+		value: 'status'
+	},
+	{
+		label: 'Last Name',
+		value: 'lastName'
+	},
+	{
+		label: 'First Name',
+		value: 'firstName'
+	}
 ]
 
 export const flattenStaffing = (data) => {
@@ -375,7 +378,7 @@ export const flattenStaffing = (data) => {
 
 	data.forEach(statusGroup => {
 		flattenedData = [
-			...flattenedData, 
+			...flattenedData,
 			...statusGroup.instructors.map(i => ({
 				organizationName: i.organizationName,
 				status: statusGroup.status,
@@ -426,29 +429,59 @@ export const studentSurveyFields = [
 
 
 export const attendanceCheckFields = [
-    {
-      label: 'Organization',
-      value: 'organizationName'
-    },
-    {
-      label: 'Status',
-      value: 'status'
-    },
-    {
-      label: 'Last Name',
-      value: 'lastName'
-    },
-    {
-      label: 'First Name',
-      value: 'firstName'
-    }
+	{
+		label: 'Organization',
+		value: 'school'
+	},
+	{
+		label: 'Class',
+		value: 'className'
+	},
+	{
+		label: 'Weekday',
+		value: 'weekday'
+	},
+	{
+		label: 'Date',
+		value: 'date'
+	},
+	{
+		label: 'Start Times',
+		value: 'startTimes'
+	},
+	{
+		label: 'End Times',
+		value: 'endTimes'
+	},
+	{
+		label: 'Instructors',
+		value: 'instructors'
+	},
+	{
+		label: 'Entry',
+		value: 'attendanceEntry'
+	}
 ]
 
 export const flattenAttendanceCheck = (data) => {
-	let flattenedResults: any[] = []
+	let flattenedResults: any[] = data.map(x => {
+
+		const timeBounds = x.timeBounds
+		
+		return {
+			school: x.school,
+			className: x.className,
+			weekday: x.instanceDate.format(DateTimeFormatter.ofPattern('eeee').withLocale(Locale.ENGLISH)),
+			date: x.instanceDate.toString(),
+			startTimes: timeBounds.map(y => y.startTime.format(DateTimeFormatter.ofPattern('h:mm a').withLocale(Locale.ENGLISH))),
+			endTimes: timeBounds.map(y => y.endTime.format(DateTimeFormatter.ofPattern('h:mm a').withLocale(Locale.ENGLISH))),
+			instructors: x.instructors.map(y => `${y.firstName} ${y.lastName}`),
+			attendanceEntry: x.attendanceEntry
+		}
+	})
+
 	return flattenedResults
 }
-
 
 export const cclc10Fields = [
 	{

--- a/GrantTracker/ClientApp/src/pages/Reporting/ReportParameters.tsx
+++ b/GrantTracker/ClientApp/src/pages/Reporting/ReportParameters.tsx
@@ -4,15 +4,16 @@ import { LocalDate } from "@js-joda/core"
 
 import Dropdown from "components/Input/Dropdown"
 
-import { OrganizationView, OrganizationYear, OrganizationYearDomain, OrganizationYearView, Quarter } from "Models/OrganizationYear"
+import { OrganizationView, OrganizationYear, OrganizationYearDomain, OrganizationYearView, Quarter, Year, YearDomain, YearView } from "Models/OrganizationYear"
 
 import api, { AxiosIdentityConfig } from "utils/api"
 import Select from "react-select"
+import { IdentityClaim } from "utils/authentication"
 
 export interface ReportParameters {
 	organizationGuid: string | undefined
 	organizationName: string | undefined
-	organizationYearGuid: string | undefined
+	year: YearView | undefined
 	startDate: LocalDate | undefined
 	endDate: LocalDate | undefined
 }
@@ -25,19 +26,18 @@ function previousMonday(date: LocalDate) {
 	return date.plusDays((-date.dayOfWeek().ordinal()) || -7)
 }
 
-export default ({onSubmit}): JSX.Element => {
+export default ({user, onSubmit}): JSX.Element => {
 	const [organizations, setOrganizations] = useState<OrganizationView[]>([])
 	const [organizationGuid, setOrgGuid] = useState<string | undefined>()
 
-	const [organizationYearsAreLoading, setOrgYearsLoading] = useState<boolean>(false)
-	const [organizationYears, setOrganizationYears] = useState<OrganizationYearView[]>([])
-	const [organizationYearGuid, setOrgYearGuid] = useState<string | undefined>('')
+	const [yearsAreLoading, setYearsAreLoading] = useState<boolean>(false)
+	const [years, setYears] = useState<YearView[]>([])
+	const [year, setYear] = useState<YearView | null>()
 
 	const [startDate, setStartDate] = useState<LocalDate | undefined>()
 	const [endDate, setEndDate] = useState<LocalDate | undefined>()
 
 	const [isSingleDateQuery, setIsSingleDateQuery] = useState<boolean>(false)
-
 
 	useEffect(() => {
 		getAuthorizedOrganizations()
@@ -57,42 +57,46 @@ export default ({onSubmit}): JSX.Element => {
 		if (!organizationGuid)
 			return
 
-		setOrgYearsLoading(true)
-		getOrganizationYears(organizationGuid)
-			.then(res => {
-				setOrganizationYears(res)
+		setYearsAreLoading(true)
+		getYears(organizationGuid)
+			.then(yearViews => {
+				setYears(yearViews)
 
-				if (res.some(orgYear => orgYear.guid == AxiosIdentityConfig.identity.organizationYearGuid))
-					var orgYearGuid: string |undefined = AxiosIdentityConfig.identity.organizationYearGuid //this should never NOT occur, really
-				else if (res.length > 0 || !orgYearGuid)
-					orgYearGuid = res[0].guid //but shit happens
-
-				setOrgYearGuid(orgYearGuid)
-
-				if (!startDate || !endDate) {
-					let orgYear = res.find(orgYear => orgYear.guid == orgYearGuid)
-					setStartDate(orgYear?.year.startDate)
-					setEndDate(orgYear?.year.endDate)
-				}
+				if (yearViews.some(orgYear => orgYear.guid == AxiosIdentityConfig.identity.organizationYearGuid))
+					setYear(yearViews.find(oy => oy.guid === AxiosIdentityConfig.identity.organizationYearGuid))
+				else if (yearViews.length > 0)
+					setYear(yearViews.find(y => y.isCurrentYear) || yearViews[0])
 			})
 			.finally(() => {
-				setOrgYearsLoading(false)
+				setYearsAreLoading(false)
 			})
 	}, [organizationGuid])
 
-	if (!organizationGuid || !organizationYearGuid)
+	useEffect(() => {
+		if (!year)
+			return
+
+		setStartDate(year.startDate)
+		setEndDate(year.endDate)
+	}, [year?.guid])
+
+	if (organizationGuid == undefined || !year)
 		return <Spinner animation="border" role="status" />
+
+	const orgOptions = user.claim == IdentityClaim.Administrator 
+		? [{ value: '', label: 'All' }, ...organizations.map(org => ({ value: org.guid, label: org.name }))]
+		: organizations.map(org => ({ value: org.guid, label: org.name }))
 
 	return (
 		<Container className='ms-0'>
 			<Form>
-				<Row>
+				<Row className='mb-3'>
 					<Col sm={3} xs={6}> 
 						<Form.Group>
 							<Form.Label htmlFor='org'>Organization</Form.Label>
 								<Select 
 									id='org'
-									options={organizations.map(org => ({ value: org.guid, label: org.name }))}
+									options={orgOptions}
 									value={{ value: organizationGuid, label: organizations.find(o => o.guid == organizationGuid)?.name}}
 									onChange={option => setOrgGuid(option.value)}
 								/>
@@ -101,15 +105,15 @@ export default ({onSubmit}): JSX.Element => {
 					<Col sm={3} xs={6}> 
 						<Form.Group>
 							<Form.Label htmlFor='school-year'>School Year <small>(Affects Staffing Only)</small></Form.Label> 
-							{organizationYearsAreLoading ? <Spinner animation="border" role="status" /> :
+							{yearsAreLoading ? <Spinner animation="border" role="status" /> :
 								<Dropdown
 									id='school-year'
-									options={organizationYears.map(orgYear => ({
-										guid: orgYear.guid,
-										label: `${orgYear.year.schoolYear} - ${Quarter[orgYear.year.quarter]}`
+									options={years.map(year => ({
+										guid: year.guid,
+										label: `${year.schoolYear} - ${Quarter[year.quarter]}`
 									}))}
-									value={organizationYearGuid}
-									onChange={(orgYearGuid: string) => {setOrgYearGuid(orgYearGuid)}}
+									value={year.guid}
+									onChange={(yearGuid: string) => {setYear(years.find(year => year.guid == yearGuid))}}
 								/>
 							}
 						</Form.Group>
@@ -161,8 +165,8 @@ export default ({onSubmit}): JSX.Element => {
 					<Col sm={3} xs={6} className='d-flex align-items-center'>	
 						<Button onClick={() => onSubmit({
 							organizationGuid,
-							organizationName: organizations?.find(x => x.guid == organizationGuid)?.name,
-							organizationYearGuid,
+							organizationName: organizations?.find(x => x.guid == organizationGuid)?.name || 'All Organizations',
+							year,
 							startDate,
 							endDate: isSingleDateQuery ? startDate : endDate
 						})}>
@@ -188,12 +192,12 @@ function getAuthorizedOrganizations(): Promise<OrganizationView[]> {
 	})
   }
 
-function getOrganizationYears(organizationGuid: string): Promise<OrganizationYearView[]> {
+function getYears(organizationGuid: string): Promise<YearView[]> {
 	return new Promise((resolve, reject) => {
 	  api
-		.get<OrganizationYearDomain[]>('dropdown/year', { params: {organizationGuid}})
+		.get<YearDomain[]>('dropdown/year', { params: {organizationGuid}})
 		.then(res => {
-		  resolve(res.data.map(x => OrganizationYear.toViewModel(x)))
+		  resolve(res.data.map(x => Year.toViewModel(x)))
 		})
 		.catch(err => {
 			reject()

--- a/GrantTracker/ClientApp/src/pages/Reporting/api.ts
+++ b/GrantTracker/ClientApp/src/pages/Reporting/api.ts
@@ -1,17 +1,17 @@
 import { LocalDate } from '@js-joda/core'
 import { DateOnly } from 'Models/DateOnly'
-import { OrganizationView, OrganizationYearView } from 'Models/OrganizationYear'
+import { OrganizationView, OrganizationYearView, YearView } from 'Models/OrganizationYear'
 import { TimeOnly } from 'Models/TimeOnly'
 import api from 'utils/api'
 
-export function getReportsAsync(startDate: LocalDate, endDate: LocalDate, organizationYearGuid: string, organizationGuid: string): Promise<any[]> {
+export function getReportsAsync(startDate: LocalDate, endDate: LocalDate, year: YearView, organizationGuid: string): Promise<any[]> {
   return new Promise((resolve, reject) => {
     api
       .get('report', {
         params: {
           startDateStr: startDate.toString(),
           endDateStr: endDate.toString(),
-          organizationYearGuid,
+          yearGuid: year.guid,
           organizationGuid: organizationGuid || null
         }
       })

--- a/GrantTracker/ClientApp/src/pages/Reporting/index.tsx
+++ b/GrantTracker/ClientApp/src/pages/Reporting/index.tsx
@@ -41,7 +41,7 @@ export default ({user}): JSX.Element => {
 	const [reportParameters, setReportParameters] = useState<ReportParameters>({
 		organizationGuid: undefined,
 		organizationName: undefined,
-		organizationYearGuid: undefined,
+		organizationYear: undefined,
 		startDate: undefined,
 		endDate: undefined
 	})
@@ -83,12 +83,13 @@ export default ({user}): JSX.Element => {
 		: `${reportParameters.startDate?.toString()}-${reportParameters.endDate?.toString()}`
 
 	function handleParameterChange(form: ReportParameters): void {
-		if (form.organizationGuid && form.organizationYearGuid && form.startDate && form.endDate)
+		console.log(form)
+		if (form.organizationGuid != undefined && form.year && form.startDate && form.endDate)
 		{
 			setIsLoading(true)
 			setSiteSessionsIsLoading(true)
 
-			getReportsAsync(form.startDate, form.endDate, form.organizationYearGuid, form.organizationGuid)
+			getReportsAsync(form.startDate, form.endDate, form.year, form.organizationGuid)
 				.then(res => {
 					setReports(res)
 				})
@@ -136,7 +137,7 @@ export default ({user}): JSX.Element => {
 
 	return (
 		<Container style={{minWidth: '90vw'}}>
-			<ReportParameterInput onSubmit={handleParameterChange} />
+			<ReportParameterInput user={user} onSubmit={handleParameterChange} />
 
 			<hr />
 
@@ -258,12 +259,13 @@ export default ({user}): JSX.Element => {
 											</Col>
 										</Row>
 								
-										<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+										<Row>
 											<Table 
 												className='m-0'
 												columns={studentAttendanceColumns} 
 												dataset={reports?.totalStudentAttendance.filter(x => x.totalDays >= studentAttendMinDays)}
 												defaultSort={{index: 0, direction: SortDirection.Ascending}}
+												maxHeight='45rem'
 											/>
 										</Row>
 									</ReportComponent>
@@ -288,12 +290,13 @@ export default ({user}): JSX.Element => {
 										fileName={`Total_Activity_${organizationFileString}_${reportDateFileString}`}
 										fileFields={activityFields}
 									>
-										<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+										<Row>
 											<Table 
 												className='m-0'
 												columns={activityReportColumns} 
 												dataset={reports?.totalActivity} 
 												defaultSort={{index: 0, direction: SortDirection.Ascending}}
+												maxHeight='45rem'
 											/>
 										</Row>
 									</ReportComponent>
@@ -308,12 +311,13 @@ export default ({user}): JSX.Element => {
 										fileName={`Site_Sessions_${organizationFileString}_${reportDateFileString}`}
 										fileFields={siteSessionFields}
 									>
-										<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+										<Row>
 											<Table 
 												className='m-0'
 												columns={siteSessionsColumns} 
 												dataset={siteSessions} 
 												defaultSort={{index: 1, direction: SortDirection.Ascending}}
+												maxHeight='45rem'
 												tableProps={{
 												  size: 'sm',
 												  style: {
@@ -335,12 +339,13 @@ export default ({user}): JSX.Element => {
 										fileName={`Summary_Of_Classes_${organizationFileString}_${reportDateFileString}`}
 										fileFields={summaryOfClassesFields}
 									>
-										<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+										<Row>
 											<Table 
 												className='m-0'
 												columns={summaryOfClassesColumns} 
 												dataset={reports?.classSummaries} 
 												defaultSort={{index: 0, direction: SortDirection.Ascending}}
+												maxHeight='45rem'
 												tableProps={{
 												  size: 'sm'
 												}}
@@ -358,12 +363,13 @@ export default ({user}): JSX.Element => {
 										fileName={`Program_Overview_${organizationFileString}_${reportDateFileString}`}
 										fileFields={programOverviewFields}
 									>
-										<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+										<Row>
 											<Table 
 												className='m-0'
 												columns={programOverviewColumns} 
 												dataset={reports?.programOverviews} 
 												defaultSort={{index: 0, direction: SortDirection.Ascending}}
+												maxHeight='45rem'
 												tableProps={{
 												  size: 'sm'
 												}}
@@ -393,12 +399,13 @@ export default ({user}): JSX.Element => {
 												</Form.Group>
 											</Row>
 							
-											<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+											<Row>
 												<Table 
 													className='m-0'
 													columns={staffingColumns} 
 													dataset={reports?.staffSummaries.find(statusGroup => statusGroup.status === staffingStatusFilter)?.instructors} 
 													defaultSort={{index: 0, direction: SortDirection.Ascending}}
+													maxHeight='45rem'
 													tableProps={{
 														size: 'sm'
 													}}
@@ -417,12 +424,13 @@ export default ({user}): JSX.Element => {
 										fileName={`Student_Survey_${organizationFileString}_${reportDateFileString}`}
 										fileFields={studentSurveyFields}
 									>
-										<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+										<Row >
 											<Table 
 												className='m-0'
 												columns={studentSurveyColumns} 
 												dataset={reports?.studentSurvey} 
 												defaultSort={{index: 0, direction: SortDirection.Ascending}}
+												maxHeight='45rem'
 												tableProps={{
 												  size: 'sm'
 												}}
@@ -436,6 +444,9 @@ export default ({user}): JSX.Element => {
 										isLoading={isLoading}
 										displayData={reports?.attendanceCheck}
 										displayName={`Attendance Check for ${reportParameters.organizationName}, ${reportDateDisplayString}`}
+										fileData={flattenAttendanceCheck(reports?.attendanceCheck)}
+										fileName={`Attendance_Check_${organizationFileString}_${reportDateFileString}`}
+										fileFields={attendanceCheckFields}
 									>
 										<Row>
 											<Col sm={3} className='p-0'>
@@ -449,12 +460,13 @@ export default ({user}): JSX.Element => {
 												/>
 											</Col>
 										</Row>
-										<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+										<Row>
 											<Table 
 												className='m-0'
 												columns={attendanceCheckColumns} 
 												dataset={reports?.attendanceCheck.filter(e => e.className.toLocaleLowerCase().includes(attendanceCheckClassFilter))} 
 												defaultSort={{index: 0, direction: SortDirection.Ascending}}
+												maxHeight='45rem'
 												tableProps={{
 													size: 'sm',
 													style: {minWidth: '1100px'}
@@ -541,12 +553,13 @@ const FamilyEngagementReport = ({isLoading, reportParameters, fileName, reportDa
 				</Col>
 			</Row>
 	
-			<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+			<Row>
 				<Table 
 					className='m-0'
 					columns={familyAttendanceColumns} 
 					dataset={filteredRecords} 
 					defaultSort={{index: 0, direction: SortDirection.Ascending}}
+					maxHeight='45rem'
 				/>
 			</Row>
 		</ReportComponent>
@@ -593,13 +606,14 @@ const PayrollAuditReport = ({isLoading, reportParameters, reportDateDisplayStrin
 				</Col>
 			</Form.Group>
 
-			<Row style={{maxHeight: '45rem', overflowY: 'auto'}}>
+			<Row>
 				<Table 
 					className='m-0'
 					columns={createPayrollAuditColumns(payrollAuditAttendingFilter, payrollAuditRegisteredFilter)} 
 					dataset={displayData} 
 					defaultSort={{index: 0, direction: SortDirection.Ascending}}
 					tableProps={{style: {minWidth: '1100px', borderCollapse: 'collapse', borderSpacing: '0 3px'}}}
+					maxHeight='45rem'
 				/>
 			</Row>
 		</ReportComponent>

--- a/GrantTracker/ClientApp/src/utils/React.ts
+++ b/GrantTracker/ClientApp/src/utils/React.ts
@@ -4,18 +4,17 @@ export function useOutsideClickListener(
   ref: React.RefObject<HTMLElement>,
   callback: () => void
 ) {
-
   const [containerRef, _] = useState(ref)
 
-  function handleDocumentClick(event: MouseEvent) {
-    if (!containerRef?.current?.contains(event.target as Node))
-      callback()
-  }
-
   useEffect(() => {
-    document.addEventListener('click', handleDocumentClick, true)
+    function handleDocumentClick(event: MouseEvent) {
+      if (ref?.current && !containerRef.current.contains(event.target as Node) && typeof(callback) == 'function')
+        callback()
+    }
+
+    document.addEventListener('mousedown', handleDocumentClick)
     return (() => {
-      document.removeEventListener('click', handleDocumentClick, true)
+      document.removeEventListener('mousedown', handleDocumentClick)
     })
-  }, [])
+  }, [ref])
 }

--- a/GrantTracker/Dal/Controllers/DropdownController.cs
+++ b/GrantTracker/Dal/Controllers/DropdownController.cs
@@ -60,12 +60,12 @@ namespace GrantTracker.Dal.Controllers
 		}
 
 		[HttpGet("year")]
-		public async Task<ActionResult<List<YearView>>> GetOrganizationYears(Guid? OrganizationGuid = default)
+		public async Task<ActionResult<List<YearView>>> GetYears(Guid? OrganizationGuid = default)
 		{
-			if (!HttpContext.User.IsAuthorizedToViewOrganization(OrganizationGuid))
+			if ((OrganizationGuid == default && !HttpContext.User.IsAdmin()) || !HttpContext.User.IsAuthorizedToViewOrganization(OrganizationGuid))
 				return Unauthorized();
 
-			var years = await _dropdownRepository.GetOrganizationYearsAsync(OrganizationGuid);
+			var years = await _dropdownRepository.GetYearsAsync(OrganizationGuid);
 			return Ok(years);
 		}
 

--- a/GrantTracker/Dal/Controllers/ReportController.cs
+++ b/GrantTracker/Dal/Controllers/ReportController.cs
@@ -5,11 +5,11 @@ using GrantTracker.Dal.Models.Views;
 using GrantTracker.Dal.Models.Dto;
 using GrantTracker.Dal.Schema;
 using GrantTracker.Dal.Schema.Sprocs.Reporting;
+using GrantTracker.Utilities;
 
 namespace GrantTracker.Dal.Controllers;
 
 [ApiController]
-//this should be restricted to Admin only
 [Route("report")]
 public class ReportController : ControllerBase
 {
@@ -21,10 +21,8 @@ public class ReportController : ControllerBase
     private readonly ILogger<ReportController> _logger;
 
     private readonly IReportRepository _reportRepository;
-	//cache settings
 	private readonly IMemoryCache _memoryCache;
 	private readonly MemoryCacheEntryOptions _cacheEntryOptions = new MemoryCacheEntryOptions();
-	//TEMPORARY until a table is created.
 	private readonly List<ReportBounds> _standardReportBounds = new()
 	{
 		//Summer: 6/1/22-7/31/22
@@ -85,13 +83,13 @@ public class ReportController : ControllerBase
 
 	//except for site sessions rn
 	[HttpGet]
-	public async Task<ActionResult<ReportsViewModel>> GetAllReportsAsync(string startDateStr, string endDateStr, Guid organizationYearGuid, Guid organizationGuid = default)
+	public async Task<ActionResult<ReportsViewModel>> GetAllReportsAsync(string startDateStr, string endDateStr, Guid yearGuid, Guid? organizationGuid = null)
 	{
 		try
 		{
 			DateOnly startDate = DateOnly.Parse(startDateStr);
 			DateOnly endDate = DateOnly.Parse(endDateStr);
-			var reports = await _reportRepository.RunAllReportQueriesAsync(startDate, endDate, organizationYearGuid, organizationGuid);
+			var reports = await _reportRepository.RunAllReportQueriesAsync(startDate, endDate, yearGuid, organizationGuid);
 			return Ok(reports);
 		}
 		catch (Exception ex)
@@ -106,7 +104,7 @@ public class ReportController : ControllerBase
 	{
 		try
         {
-			var report = await _reportRepository.GetCCLC10(DateOnly.Parse(startDateStr), DateOnly.Parse(endDateStr));
+            var report = await _reportRepository.GetCCLC10(DateOnly.Parse(startDateStr), DateOnly.Parse(endDateStr));
 			return Ok(report);
         }
 		catch (Exception ex)
@@ -117,11 +115,11 @@ public class ReportController : ControllerBase
 	}
 
 	[HttpGet("siteSessions")]
-	public async Task<ActionResult<List<SiteSessionViewModel>>> GetSiteSessionsAsync(string startDateStr, string endDateStr, Guid organizationGuid = default)
+	public async Task<ActionResult<List<SiteSessionViewModel>>> GetSiteSessionsAsync(string startDateStr, string endDateStr, Guid? organizationGuid = null)
 	{
-		try 
-		{ 
-			DateOnly startDate = DateOnly.Parse(startDateStr);
+		try
+        {
+            DateOnly startDate = DateOnly.Parse(startDateStr);
 			DateOnly endDate = DateOnly.Parse(endDateStr);
 			var siteSessions = await _reportRepository.GetSiteSessionsAsync(startDate, endDate, organizationGuid);
 			return Ok(siteSessions);

--- a/GrantTracker/Dal/Controllers/SessionController.cs
+++ b/GrantTracker/Dal/Controllers/SessionController.cs
@@ -263,6 +263,11 @@ public class SessionController : ControllerBase
                 conflicts = await _sessionRepository.ValidateStudentAttendanceAsync(sessionAttendance.Date, sessionAttendance.StudentRecords);
 				sessionAttendance.StudentRecords = sessionAttendance.StudentRecords.ExceptBy(conflicts.Select(x => x.StudentSchoolYearGuid), record => record.Id).ToList();
 			}
+			else
+			{
+				sessionAttendance.StudentRecords = sessionAttendance.StudentRecords.Where(sr => sr.FamilyAttendance.Any()).ToList();
+				sessionAttendance.StudentRecords.ForEach(sr => { sr.Times = new(); });
+			}
 
             await _attendanceRepository.AddAttendanceAsync(sessionGuid, sessionAttendance);
 

--- a/GrantTracker/Dal/Repositories/AttendanceRepository/AttendanceRepository.cs
+++ b/GrantTracker/Dal/Repositories/AttendanceRepository/AttendanceRepository.cs
@@ -46,8 +46,8 @@ public class AttendanceRepository : IAttendanceRepository
 			? await query
 				.Include(ar => ar.FamilyAttendance).ThenInclude(sa => sa.StudentSchoolYear).ThenInclude(ssy => ssy.Student)
 				.SingleAsync()
-			: await query.Include(ar => ar.FamilyAttendance)
-				.Include(ar => ar.StudentAttendance).ThenInclude(sa => sa.StudentSchoolYear).ThenInclude(ssy => ssy.Student)
+			: await query.Include(ar => ar.FamilyAttendance).ThenInclude(sa => sa.StudentSchoolYear).ThenInclude(ssy => ssy.Student)
+                .Include(ar => ar.StudentAttendance).ThenInclude(sa => sa.StudentSchoolYear).ThenInclude(ssy => ssy.Student)
 				.Include(ar => ar.StudentAttendance).ThenInclude(sa => sa.TimeRecords)
 				.SingleAsync();
 
@@ -65,7 +65,8 @@ public class AttendanceRepository : IAttendanceRepository
 				AttendanceGuid = record.Guid,
 				InstanceDate = record.InstanceDate,
 				InstructorCount = record.InstructorAttendance.Count,
-				StudentCount = record.StudentAttendance.Count
+				StudentCount = record.StudentAttendance.Count,
+				FamilyCount = record.FamilyAttendance.Count
 			})
 			.OrderByDescending(x => x.InstanceDate)
 			.ToListAsync();
@@ -155,6 +156,7 @@ public class AttendanceRepository : IAttendanceRepository
 			})
 			.ToList(),
 			StudentAttendance = sessionAttendance.StudentRecords
+				.Where(sr => sr.Times.Any())
 				.Select(sr => {
 					Guid studentAttendanceRecordGuid = Guid.NewGuid();
 

--- a/GrantTracker/Dal/Repositories/DropdownRepository/DropdownRepository.cs
+++ b/GrantTracker/Dal/Repositories/DropdownRepository/DropdownRepository.cs
@@ -99,21 +99,18 @@ namespace GrantTracker.Dal.Repositories.DropdownRepository
 			return organizations.Select(OrganizationView.FromDatabase).ToList();
 		}
 
-		public async Task<List<OrganizationYearView>> GetOrganizationYearsAsync(Guid? organizationGuid = default)
+		public async Task<List<YearView>> GetYearsAsync(Guid? organizationGuid = null)
 		{
-			var organizations = await _grantContext
+			var years = await _grantContext
 				.Organizations
 				.AsNoTracking()
-				.Where(org => organizationGuid == default || org.OrganizationGuid == organizationGuid)
+				.Where(org => organizationGuid == null || org.OrganizationGuid == organizationGuid)
 				.Include(org => org.Years).ThenInclude(oy => oy.Year)
+				.SelectMany(org => org.Years)
+				.Select(oy => oy.Year)
 				.ToListAsync();
 
-			var organizationYears = organizations
-				.SelectMany(o => o.Years)
-				.OrderByDescending(oy => oy.Year.SchoolYear).ThenByDescending(oy => oy.Year.Quarter)
-				.ToList();
-
-			return organizationYears.Select(OrganizationYearView.FromDatabase).ToList();
+			return years.Select(YearView.FromDatabase).ToList();
 		}
 	}
 }

--- a/GrantTracker/Dal/Repositories/DropdownRepository/IDropdownRepository.cs
+++ b/GrantTracker/Dal/Repositories/DropdownRepository/IDropdownRepository.cs
@@ -1,19 +1,18 @@
 ﻿using GrantTracker.Dal.Models.Views;
 
-namespace GrantTracker.Dal.Repositories.DropdownRepository
+namespace GrantTracker.Dal.Repositories.DropdownRepository;
+
+public interface IDropdownRepository
 {
-	public interface IDropdownRepository
-	{
-		public Task<SessionDropdownOptions> GetAllSessionDropdownOptionsAsync();
+	Task<SessionDropdownOptions> GetAllSessionDropdownOptionsAsync();
 
-		public Task<DropdownOptions> GetAllDropdownOptionsAsync();
+	Task<DropdownOptions> GetAllDropdownOptionsAsync();
 
-		public Task<List<DropdownOption>> GetInstructorStatusesAsync();
+	Task<List<DropdownOption>> GetInstructorStatusesAsync();
 
-		public Task<List<DropdownOption>> GetGradesAsync();
+	Task<List<DropdownOption>> GetGradesAsync();
 
-		public Task<List<OrganizationView>> GetOrganizationsAsync(bool UserIsAdmin, List<Guid> HomeOrganizationGuid);
+	Task<List<OrganizationView>> GetOrganizationsAsync(bool UserIsAdmin, List<Guid> HomeOrganizationGuid);
 
-		public Task<List<OrganizationYearView>> GetOrganizationYearsAsync(Guid? organizationGuid);
-	}
+	Task<List<YearView>> GetYearsAsync(Guid? organizationGuid = default);
 }

--- a/GrantTracker/Dal/Repositories/OrganizationRepository/IOrganizationRepository.cs
+++ b/GrantTracker/Dal/Repositories/OrganizationRepository/IOrganizationRepository.cs
@@ -18,7 +18,7 @@ public interface IOrganizationRepository
     Task DeleteOrganizationAsync(Guid OrganizationGuid);
 
 
-    Task<List<OrganizationBlackoutDate>> GetBlackoutDatesAsync(Guid OrganizationGuid);
+    Task<List<OrganizationBlackoutDate>> GetBlackoutDatesAsync(Guid? organizationGuid = null);
     Task AddBlackoutDateAsync(Guid OrganizationGuid, DateOnly BlackoutDate);
     Task DeleteBlackoutDateAsync(Guid BlackoutDateGuid);
 }

--- a/GrantTracker/Dal/Repositories/OrganizationRepository/OrganizationRepository.cs
+++ b/GrantTracker/Dal/Repositories/OrganizationRepository/OrganizationRepository.cs
@@ -92,9 +92,9 @@ public class OrganizationRepository : IOrganizationRepository
 		return organizations.Select(OrganizationView.FromDatabase).ToList();
     }
 
-	public async Task<List<OrganizationBlackoutDate>> GetBlackoutDatesAsync(Guid OrganizationGuid)
+	public async Task<List<OrganizationBlackoutDate>> GetBlackoutDatesAsync(Guid? organizationGuid = null)
 	{
-		return await _grantContext.BlackoutDates.AsNoTracking().Where(x => x.OrganizationGuid == OrganizationGuid).ToListAsync();
+		return await _grantContext.BlackoutDates.AsNoTracking().Where(x => organizationGuid == null || x.OrganizationGuid == organizationGuid).ToListAsync();
     }
 
     public async Task AddBlackoutDateAsync(Guid OrganizationGuid, DateOnly BlackoutDate)

--- a/GrantTracker/Dal/Repositories/ReportRepository/IReportRepository.cs
+++ b/GrantTracker/Dal/Repositories/ReportRepository/IReportRepository.cs
@@ -6,7 +6,7 @@ namespace GrantTracker.Dal.Repositories.ReportRepository;
 
 public interface IReportRepository
 {
-	Task<ReportsViewModel> RunAllReportQueriesAsync(DateOnly startDate, DateOnly endDate, Guid organizationYearGuid, Guid? organizationGuid = null);
+	Task<ReportsViewModel> RunAllReportQueriesAsync(DateOnly startDate, DateOnly endDate, Guid? yearGuid = null, Guid? organizationGuid = null);
 
 	Task<List<CCLC10ViewModel>> GetCCLC10(DateOnly startDate, DateOnly endDate);
 

--- a/GrantTracker/Dal/Schema/Sprocs/Reporting/AttendanceCheck.cs
+++ b/GrantTracker/Dal/Schema/Sprocs/Reporting/AttendanceCheck.cs
@@ -10,6 +10,7 @@ public class AttendanceCheckViewModel
 {
     public Guid SessionGuid { get; set; }
     public DateOnly InstanceDate { get; set; }
+    public Guid OrganizationGuid { get; set; }
     public string School { get; set; }
     public string ClassName { get; set; }
     public bool AttendanceEntry { get; set; }

--- a/GrantTracker/Program.cs
+++ b/GrantTracker/Program.cs
@@ -10,7 +10,7 @@ IConfiguration configuration = builder.Configuration;
 const string origins = "_allowDevOrigins";
 
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
     .Enrich.FromLogContext()
     .WriteTo.Console()
     .CreateBootstrapLogger();


### PR DESCRIPTION
Family attendance can now set the student absent without parents absent. Family/Parent attendance now displays correctly and appropriately avoids creating erroneous student records. Start/end time inputs now update separately to avoid erroneous overwrites with stale data.