### PR TITLE
Table sort regression fix

### DIFF
--- a/GrantTracker/ClientApp/src/components/BTable/index.tsx
+++ b/GrantTracker/ClientApp/src/components/BTable/index.tsx
@@ -62,9 +62,11 @@ export default ({ columns, dataset, rowProps, defaultSort, maxHeight, maxRows = 
 
     setSortIndex(value)
     setSortDirection(direction)
-    setPageNumber(1)
+    setPageNumber(0)
     setDataToRender(sortDataset(dataset, value, direction, columns))
   }
+
+  const paginatedData = dataToRender?.slice(pageNumber * maxRows, (pageNumber + 1) * maxRows)
 
   return (
     <div>
@@ -104,7 +106,7 @@ export default ({ columns, dataset, rowProps, defaultSort, maxHeight, maxRows = 
           }
           <Body
             columns={columns}
-            dataset={dataToRender?.slice(pageNumber  * maxRows, (pageNumber + 1) * maxRows)}
+            dataset={paginatedData}
             rowProps={rowProps}
             indexed={indexed}
             sortIndex={sortIndex}

--- a/GrantTracker/ClientApp/src/components/SessionDetails/AttendanceHistory/RecordDisplay.tsx
+++ b/GrantTracker/ClientApp/src/components/SessionDetails/AttendanceHistory/RecordDisplay.tsx
@@ -104,7 +104,7 @@ function addFamilyColumn (columns: Column[]): Column[] {
       transform: (familyAttendanceRecord) => 
         <div className='d-flex align-items-center flex-wrap h-100'>
           {
-            familyAttendanceRecord.map(fa => (
+            familyAttendanceRecord?.map(fa => (
               <>
                 <span className='w-50 text-center'>{FamilyMemberOps.toString(fa.familyMember)}</span>
                 <span className='w-50 text-center'>{fa.count}</span>

--- a/GrantTracker/ClientApp/src/pages/Reporting/Definitions/Columns.tsx
+++ b/GrantTracker/ClientApp/src/pages/Reporting/Definitions/Columns.tsx
@@ -562,7 +562,7 @@ export const attendanceCheckColumns: Column[] = [
 		cellProps: { className: 'text-center'},
 		transform: (attendanceEntry: boolean) => attendanceEntry ? <span className='text-success fw-bold'>Y</span> : <span className='text-danger fw-bold'>N</span>,
 		sortable: true,
-		sortTransform: (attendanceEntry: boolean) => attendanceEntry ? 1 : 0
+		sortTransform: (attendanceEntry: boolean) => attendanceEntry ? "1" : "0"
 	}
 ]
 

--- a/GrantTracker/Dal/Models/Views/AttendanceViews.cs
+++ b/GrantTracker/Dal/Models/Views/AttendanceViews.cs
@@ -52,8 +52,9 @@ namespace GrantTracker.Dal.Models.Views
 				studentAttendanceRecords = record.FamilyAttendance
 					.GroupBy(fa => fa.StudentSchoolYearGuid,
 						(ssyGuid, group) => new StudentAttendanceViewModel()
-						{
-							StudentSchoolYear = StudentSchoolYearViewModel.FromDatabase(group.First().StudentSchoolYear),
+                        {
+                            Guid = group.First().AttendanceRecordGuid,
+                            StudentSchoolYear = StudentSchoolYearViewModel.FromDatabase(group.First().StudentSchoolYear),
 							TimeRecords = record.StudentAttendance
 								.FirstOrDefault(sa => sa.StudentSchoolYearGuid == ssyGuid)
 								?.TimeRecords
@@ -77,6 +78,15 @@ namespace GrantTracker.Dal.Models.Views
                         Guid = attend.Guid,
                         StudentSchoolYear = StudentSchoolYearViewModel.FromDatabase(attend.StudentSchoolYear),
                         TimeRecords = attend.TimeRecords.Select(time => AttendanceTimeRecordViewModel.FromDatabase(time)).ToList(),
+						FamilyAttendance = record.FamilyAttendance
+							.Where(fa => fa.StudentSchoolYearGuid == attend.StudentSchoolYearGuid)
+                            .GroupBy(fa => fa.FamilyMember,
+                            (familyMember, group) => new FamilyAttendanceViewModel
+                            {
+                                FamilyMember = familyMember,
+                                Count = group.Count()
+                            })
+                            .ToList()
                     })
                     .Concat(studentAttendanceRecords)
 					.ToList();


### PR DESCRIPTION
Table sorting is now not incorrectly offset to page 1, and sorting on true/false values sorts correctly with a string rather than integer.